### PR TITLE
Add options for RPM Fusion, Nvidia, ZRAM, Virtual Memory and DNF configuration

### DIFF
--- a/bruh.txt
+++ b/bruh.txt
@@ -1,0 +1,3 @@
+[main]
+max_parallel_downloads=10
+fastestmirror=true

--- a/bruh.txt
+++ b/bruh.txt
@@ -1,3 +1,0 @@
-[main]
-max_parallel_downloads=10
-fastestmirror=true

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-#thinking of like check before installing that explains shit
-#also having like a "here's how you can do it manually if the config is different on your pc"
+# Future Feature: "here's how you can do it manually if the config is different on your pc"
 
 art="
 ┏┓┓┏┏┓┏┳┓┏┓┳┳┓  ┳┳┓┏┓┳┓┏┓┏┓┏┓┳┓  ┏  ┓ ┏┓ ┏┓┏┓┓
@@ -390,5 +389,3 @@ while true; do
 esac
 
 done
-
-

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+#thinking of like check before installing that explains shit
+#also having like a "here's how you can do it manually if the config is different on your pc"
+
 art="
 ┏┓┓┏┏┓┏┳┓┏┓┳┳┓  ┳┳┓┏┓┳┓┏┓┏┓┏┓┳┓  ┏  ┓ ┏┓ ┏┓┏┓┓
 ┗┓┗┫┗┓ ┃ ┣ ┃┃┃  ┃┃┃┣┫┃┃┣┫┃┓┣ ┣┫  ┃┓┏┃ ┃┫ ┣┓┗┫┃
@@ -24,6 +27,29 @@ blue='\e[0;34m'
 white='\e[0;37m'
 red='\e[0;31m'
 yellow='\e[1;33m'
+
+packageToInstall(){
+	packagesNeeded="$1"
+	if [ -x "$(command -v apt-get)" ];
+	then
+		sudo apt-get install "${packagesNeeded[@]}"
+
+	elif [ -x "$(command -v dnf)" ];
+	then
+		sudo dnf install "${packagesNeeded[@]}"
+
+	elif [ -x "$(command -v zypper)" ];
+	then
+		sudo zypper install "${packagesNeeded[@]}"
+
+	elif [ -x "$(command -v pacman)" ];
+	then
+		sudo pacman -S "${packagesNeeded[@]}"
+
+	else
+		echo "FAILED TO INSTALL: Package manager not found. Try manually installing: "${packagesNeeded[@]}"">&2;
+	fi
+}
 
 read -rp "Press any key to continue..."
 
@@ -65,8 +91,6 @@ print_help(){
 	echo -e "${red}fed${white} - Fedora-based"
 	echo -e "${red}arch${white} - Arch-based"
 	echo -e "${red}deb${white} - Debian-based"
-
-
 	echo -e ""
 	echo -e "${yellow}ex${white} - Exit the program"
 }
@@ -75,19 +99,22 @@ fedora(){
 	echo -e "${blue}**************************************${white}"
 	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
 	echo -e "${blue}--------------------------------------${white}"
-
 	echo -e "${green}FEDORA${white}"
+	echo -e ""
 	echo -e "${red}rpm${white} - RPM Fusion"
+	echo -e "${red}dnf${white} - DNF Config"
+	echo -e "${red}zram${white} - Edit zram swap size"
+	echo -e "${red}vmax${white} - Increase vm.max_map_count"
 	echo -e "${red}vir${white} - Virtualization"
-	echo -e "${red}upt${white} - Full System Upgrade"
-	echo -e "${red}rpm${white} - Nvidia Driver"
+	echo -e "${red}upg${white} - Full System Upgrade"
+	echo -e "${red}nvi${white} - Install NVIDIA Driver and CUDA"
 }
 
 debian(){
 	echo -e "${blue}**************************************${white}"
 	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
 	echo -e "${blue}--------------------------------------${white}"
-
+	echo -e ""
 	echo -e "${green}DEBIAN${white}"
 	echo -e "${red}rpm${white} - Nvidia Driver"
 	echo -e "${red}vir${white} - Virtualization"
@@ -98,7 +125,7 @@ arch(){
 	echo -e "${blue}**************************************${white}"
 	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
 	echo -e "${blue}--------------------------------------${white}"
-
+	echo -e ""
 	echo -e "${green}ARCH${white}"
 	echo -e "${red}rpm${white} - Nvidia Driver"
 	echo -e "${red}upt${white} - Full System Upgrade"
@@ -225,11 +252,14 @@ while true; do
 
 	"pkg")
 		clear
+		read -rp "Package to install: " pkg_select;
+		packageToInstall "$pkg_select"
 		read -rp "Press enter to continue..."
 		;;
 
 	"fast")
 		clear
+		packageToInstall "fastfetch"
 		read -rp "Press enter to continue..."
 		;;
 
@@ -242,6 +272,16 @@ while true; do
 	"fed")
 		clear
 		fedora
+		read -rp "Selection > " fed_select;
+    	case $fed_select in
+		"rpm")
+			sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+			sudo dnf update @core
+			;;
+		"nvi")
+			sudo dnf install akmod-nvidia xorg-x11-drv-nvidia-cuda
+			;;
+		esac
 		read -rp "Press enter to continue..."
 		;;
 

--- a/start.sh
+++ b/start.sh
@@ -51,7 +51,7 @@ packageToInstall(){
 	fi
 }
 
-read -rp "Press any key to continue..."
+read -rp "Welcome to Linush! Press enter to continue..."
 
 print_help(){
 	echo -e "${blue}**************************************${white}"
@@ -275,11 +275,66 @@ while true; do
 		read -rp "Selection > " fed_select;
     	case $fed_select in
 		"rpm")
-			sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
-			sudo dnf update @core
+			echo "RPM Fusion is a repository with non-free software like propriatery nvidia drivers."
+			read -p "Do you want to install RPM Fusion? (y/n) > " -n 1 -r # One letter only
+			echo ""
+			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name
+				sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+				sudo dnf update @core
 			;;
 		"nvi")
-			sudo dnf install akmod-nvidia xorg-x11-drv-nvidia-cuda
+			echo "For best performance on Linux, it's best to use the propriatery nvidia driver."
+			read -p "Do you want to install the nvidia driver? (y/n) > " -n 1 -r # One letter only
+			echo ""
+			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name
+				if dnf repolist | grep rpmfusion-nonfree; then
+					dnf install akmod-nvidia xorg-x11-drv-nvidia-cuda
+				else
+					echo "ERROR: RPMFUSION NOT FOUND!"
+			;;
+		"zram")
+			echo "ZRAM is a modern implementation of the swapfile."
+			read -p "Do you want to increase your zram size? (y/n) > " -n 1 -r # One letter only
+			echo ""
+			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name
+				read -rp "Type size in GB for zram (Half of your RAM is a good place to start): " zram_size;
+				if [[ "$zram_size" =~ ^[0-9]+$ ]]; then
+					sed -i "/zram-size/c\\zram-size = $zram_size * 1024" "/usr/lib/systemd/zram-generator.conf"
+				else
+					echo "ERROR: INVALID INTEGER!"
+				fi
+			fi
+			;;
+		"vmax")
+			echo -e "vm.max_map_count is the virtual memory limit on your machine, \nincreasing it can help with performance in games like Star Citizen."
+			echo ""
+			read -p "Do you want to increase your virtual memory to a recommended limit? (y/n) > " -n 1 -r # One letter only
+			echo ""
+			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name
+				sysctl -w vm.max_map_count=16777216
+			fi
+			;;
+		"dnf")
+			echo ""
+			echo -e "By default, DNF has pretty conservative settings for max_parallel_downloads and using the fastest mirror.\nAdding more capacity and allowing fastest mirror can speed up package handling."
+			echo ""
+			read -ep "Do you want to increase max_parallel_download and make sure to always use the fastest mirror available? (y/n) > " -n 1 -r # One letter only
+			echo ""
+			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name
+				if grep -q "max_parallel_downloads" /etc/dnf/dnf.conf; then
+    				sed -i 's/^max_parallel_downloads=.*/max_parallel_downloads=10/' /etc/dnf/dnf.conf
+				else
+    				echo -e "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
+				fi
+
+				if grep -q "fastestmirror" /etc/dnf/dnf.conf; then
+    				sed -i 's/^fastestmirror=.*/fastestmirror=true/' /etc/dnf/dnf.conf
+				else
+    				echo -e "fastestmirror=true" >> /etc/dnf/dnf.conf
+				fi
+				echo -e "Increased max_parallel_download to 10 and set fastestmirror to true."
+				echo ""
+			fi
 			;;
 		esac
 		read -rp "Press enter to continue..."

--- a/start.sh
+++ b/start.sh
@@ -192,4 +192,4 @@ while true; do
 		read -rp "Press enter to continue..."
         ;;		
 esac
-done
+done # for when switch case is done

--- a/start.sh
+++ b/start.sh
@@ -274,7 +274,7 @@ while true; do
 		read -rp "Selection > " fed_select;
     	case $fed_select in
 		"rpm")
-			echo "RPM Fusion is a repository with non-free software like propriatery nvidia drivers."
+			echo "RPM Fusion is a repository with non-free software like proprietary nvidia drivers."
 			read -p "Do you want to install RPM Fusion? (y/n) > " -n 1 -r # One letter only
 			echo ""
 			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name
@@ -282,7 +282,7 @@ while true; do
 				sudo dnf update @core
 			;;
 		"nvi")
-			echo "For best performance on Linux, it's best to use the propriatery nvidia driver."
+			echo "For best performance on Linux, it's best to use the proprietary nvidia driver."
 			read -p "Do you want to install the nvidia driver? (y/n) > " -n 1 -r # One letter only
 			echo ""
 			if [[ $REPLY =~ ^[Yy]$ ]]; then # Reply is default variable name

--- a/start.sh
+++ b/start.sh
@@ -192,4 +192,4 @@ while true; do
 		read -rp "Press enter to continue..."
         ;;		
 esac
-done # for when switch case is done
+done

--- a/start.sh
+++ b/start.sh
@@ -29,7 +29,7 @@ read -rp "Press any key to continue..."
 
 print_help(){
 	echo -e "${blue}**************************************${white}"
-	echo "       SYSTEM MANAGER (v0.1-rewrite)          "
+	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
 	echo -e "${blue}--------------------------------------${white}"
 	echo ""
 	echo -e "${green}NETWORK${white}"
@@ -56,15 +56,58 @@ print_help(){
 	echo -e "${red}fm${white} - Modify folder properties"
 	echo -e "${red}fd${white} - Delete a folder"
 	echo ""
-	echo -e "${green}OTHER${white}"
+	echo -e "${green}PACKAGES${white}"
 	echo -e "${red}pkg${white} - Install, Update or Remove packages"
+	echo -e "${red}fast${white} - Fastfetch"
+	echo -e "${red}star${white} - Starship"
+	echo -e ""
+	echo -e "${green}DISTROS${white}"
+	echo -e "${red}fed${white} - Fedora-based"
+	echo -e "${red}arch${white} - Arch-based"
+	echo -e "${red}deb${white} - Debian-based"
+
+
 	echo -e ""
 	echo -e "${yellow}ex${white} - Exit the program"
 }
 
+fedora(){
+	echo -e "${blue}**************************************${white}"
+	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
+	echo -e "${blue}--------------------------------------${white}"
+
+	echo -e "${green}FEDORA${white}"
+	echo -e "${red}rpm${white} - RPM Fusion"
+	echo -e "${red}vir${white} - Virtualization"
+	echo -e "${red}upt${white} - Full System Upgrade"
+	echo -e "${red}rpm${white} - Nvidia Driver"
+}
+
+debian(){
+	echo -e "${blue}**************************************${white}"
+	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
+	echo -e "${blue}--------------------------------------${white}"
+
+	echo -e "${green}DEBIAN${white}"
+	echo -e "${red}rpm${white} - Nvidia Driver"
+	echo -e "${red}vir${white} - Virtualization"
+	echo -e "${red}upt${white} - Full System Upgrade"
+}
+
+arch(){
+	echo -e "${blue}**************************************${white}"
+	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
+	echo -e "${blue}--------------------------------------${white}"
+
+	echo -e "${green}ARCH${white}"
+	echo -e "${red}rpm${white} - Nvidia Driver"
+	echo -e "${red}upt${white} - Full System Upgrade"
+	echo -e "${red}vir${white} - Virtualization"
+}
+
 sysman_logo(){
 	echo -e "${blue}**************************************${white}"
-	echo "       SYSTEM MANAGER (v0.1-rewrite)          "
+	echo "     SYSTEM MANAGER (v0.1-rewrite)     "
 	echo -e "${blue}--------------------------------------${white}"
 }
 
@@ -182,6 +225,35 @@ while true; do
 
 	"pkg")
 		clear
+		read -rp "Press enter to continue..."
+		;;
+
+	"fast")
+		clear
+		read -rp "Press enter to continue..."
+		;;
+
+	"star")
+		clear
+		curl -sS https://starship.rs/install.sh | sh
+		read -rp "Press enter to continue..."
+		;;
+	
+	"fed")
+		clear
+		fedora
+		read -rp "Press enter to continue..."
+		;;
+
+	"deb")
+		clear
+		debian
+		read -rp "Press enter to continue..."
+		;;
+
+	"arch")
+		clear
+		arch
 		read -rp "Press enter to continue..."
 		;;
 


### PR DESCRIPTION
Script always asks user for confirmation.

RPM Fusion can now be enabled.
Nvidia's propriatery driver and CUDA support from rpmfusion can be installed with check for repo being installed.
ZRAM can be configured with int only read, no checks if normal swapfile is used though.
Virtual memory (vm.max_map_count) can be set to recommended 16777216 for applications like star citizen.
DNF will automatically configure to have max_parallel_downloads=10 and fastestmirror=true with checks for existing settings.
